### PR TITLE
Support Button Text

### DIFF
--- a/src/ButtonCircle/ButtonCircle.FormsPlugin.Android/ButtonCircleRenderer.cs
+++ b/src/ButtonCircle/ButtonCircle.FormsPlugin.Android/ButtonCircleRenderer.cs
@@ -46,8 +46,17 @@ namespace ButtonCircle.FormsPlugin.Droid
                     SetLayerType(LayerType.Software, null);
                 }
             }
-            Control.Typeface = Typeface.CreateFromAsset(Forms.Context.Assets, "MaterialIcons-Regular.ttf");
-            Element.Text = ((CircleButton)Element).Icon;
+
+            if (!String.IsNullOrEmpty(((CircleButton)Element).Text))
+            {
+                Control.Typeface = Typeface.Create(Element.FontFamily, TypefaceStyle.Normal);
+				Element.Text = ((CircleButton)Element).Text;
+            }
+            else
+            {
+                Control.Typeface = Typeface.CreateFromAsset(Forms.Context.Assets, "MaterialIcons-Regular.ttf");
+                Element.Text = ((CircleButton)Element).Icon;
+            }
         }
 
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -56,9 +65,19 @@ namespace ButtonCircle.FormsPlugin.Droid
 
             if (e.PropertyName == CircleButton.BorderColorProperty.PropertyName ||
               e.PropertyName == CircleButton.BorderThicknessProperty.PropertyName ||
-              e.PropertyName == CircleButton.IconProperty.PropertyName)
+              e.PropertyName == CircleButton.IconProperty.PropertyName ||
+              e.PropertyName == CircleButton.TextProperty.PropertyName)
             {
-                Element.Text = ((CircleButton)Element).Icon;
+				if (!String.IsNullOrEmpty(((CircleButton)Element).Text))
+				{
+					Control.Typeface = Typeface.Create(Element.FontFamily, TypefaceStyle.Normal);
+					Element.Text = ((CircleButton)Element).Text;
+				}
+				else
+				{
+					Control.Typeface = Typeface.CreateFromAsset(Forms.Context.Assets, "MaterialIcons-Regular.ttf");
+					Element.Text = ((CircleButton)Element).Icon;
+				}
                 this.Invalidate();
             }
         }

--- a/src/ButtonCircle/ButtonCircle.FormsPlugin.iOS/ButtonCircleRenderer.cs
+++ b/src/ButtonCircle/ButtonCircle.FormsPlugin.iOS/ButtonCircleRenderer.cs
@@ -38,14 +38,14 @@ namespace ButtonCircle.FormsPlugin.iOS
 
             CreateCircle();
             
-            if(!String.IsNulLOrEmpty(((CircleButton)Element).Icon)
+            if(!String.IsNullOrEmpty(((CircleButton)Element).Text))
             {
-                Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
-                Element.Text = ((CircleButton)Element).Icon;
+                Control.Font = Font.OfSize(Element.FontFamily, Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+				Element.Text = ((CircleButton)Element).Text;
             }
             else {
-//                Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
-                Element.Text = ((CircleButton)Element).Text;
+                Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                Element.Text = ((CircleButton)Element).Icon;
             }
         }
         /// <summary>
@@ -67,13 +67,14 @@ namespace ButtonCircle.FormsPlugin.iOS
             {
                 CreateCircle();
                
-               if(!String.IsNulLOrEmpty(((CircleButton)Element).Icon)
-               {
-                    Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
-                    Element.Text = ((CircleButton)Element).Icon;
+                if(!String.IsNullOrEmpty(((CircleButton)Element).Text))
+                {
+                	Control.Font = Font.OfSize(Element.FontFamily, Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                	Element.Text = ((CircleButton)Element).Text;
                 }
                 else {
-                    Element.Text = ((CircleButton)Element).Text;
+                    Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                    Element.Text = ((CircleButton)Element).Icon;
                 }
             }
         }

--- a/src/ButtonCircle/ButtonCircle.FormsPlugin.iOS/ButtonCircleRenderer.cs
+++ b/src/ButtonCircle/ButtonCircle.FormsPlugin.iOS/ButtonCircleRenderer.cs
@@ -37,8 +37,16 @@ namespace ButtonCircle.FormsPlugin.iOS
                 throw new InvalidOperationException(String.Format("Cannot convert {0} into {1}", Element.Text, typeof(Icons))); ;
 
             CreateCircle();
-            Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
-            Element.Text = ((CircleButton)Element).Icon;
+            
+            if(!String.IsNulLOrEmpty(((CircleButton)Element).Icon)
+            {
+                Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                Element.Text = ((CircleButton)Element).Icon;
+            }
+            else {
+//                Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                Element.Text = ((CircleButton)Element).Text;
+            }
         }
         /// <summary>
         /// 
@@ -54,11 +62,19 @@ namespace ButtonCircle.FormsPlugin.iOS
                 e.PropertyName == VisualElement.WidthProperty.PropertyName ||
               e.PropertyName == CircleButton.BorderColorProperty.PropertyName ||
               e.PropertyName == CircleButton.BorderThicknessProperty.PropertyName ||
-              e.PropertyName == CircleButton.IconProperty.PropertyName)
+              e.PropertyName == CircleButton.IconProperty.PropertyName ||
+              e.PropertyName == CircleButton.TextProperty.PropertyName)
             {
                 CreateCircle();
                
-                Element.Text = ((CircleButton)Element).Icon;
+               if(!String.IsNulLOrEmpty(((CircleButton)Element).Icon)
+               {
+                    Control.Font = Font.OfSize("MaterialIcons-Regular", Element.FontSize).WithAttributes(Element.FontAttributes).ToUIFont();
+                    Element.Text = ((CircleButton)Element).Icon;
+                }
+                else {
+                    Element.Text = ((CircleButton)Element).Text;
+                }
             }
         }
 


### PR DESCRIPTION
I updated the iOS and Android renderer to support using the Icon font or just regular text in the Text attribute. If the Text attribute is set then it uses the Text, otherwise it uses the Icon.